### PR TITLE
Make it possible to specify request headers

### DIFF
--- a/lib/presto/metrics/client.rb
+++ b/lib/presto/metrics/client.rb
@@ -16,6 +16,7 @@ module Presto
         @query_path = opts[:query_path] || '/v1/query'
         @node_path = opts[:node_path] || '/v1/node'
         @caml_case = opts[:caml_case] || false
+        @headers = opts[:headers] || {}
       end
 
       @@MBEAN_ALIAS = {
@@ -79,7 +80,7 @@ module Presto
       end
 
       def get(path, default='{}')
-        resp = HTTParty.get(URI.encode("#{@endpoint}#{path}"))
+        resp = HTTParty.get(URI.encode("#{@endpoint}#{path}"), headers: @headers)
         if resp.code == 200
           resp.body
         else


### PR DESCRIPTION
Recent versions of Presto (and Trino) requires `X-Presto-User` header (or basic authentication) for HTTP access even on public REST endpoints, so the ability to specify arbitrary request headers would be helpful when we use HTTP for internal requests. 

By the way, `X-Presto-User`header  is not required if we use HTTPS.