### PR TITLE
Replace URL.encode to be able to run both on ruby2/ruby3

### DIFF
--- a/lib/presto/metrics/client.rb
+++ b/lib/presto/metrics/client.rb
@@ -80,7 +80,8 @@ module Presto
       end
 
       def get(path, default='{}')
-        resp = HTTParty.get(URI.encode("#{@endpoint}#{path}"), headers: @headers)
+        parser = URI::Parser.new
+        resp = HTTParty.get(parser.escape("#{@endpoint}#{path}"), headers: @headers)
         if resp.code == 200
           resp.body
         else
@@ -253,4 +254,3 @@ module Presto
     end
   end
 end
-


### PR DESCRIPTION
- URL.encode is obsoleted in ruby3.
- Replace it with the escape method provided from URL::Parse
    - https://docs.ruby-lang.org/en/2.7.0/URI/RFC2396_Parser.html
    - https://docs.ruby-lang.org/en/3.0/URI/RFC2396_Parser.html