### PR TITLE
Update supported ruby versions

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -1,5 +1,6 @@
 ---
 name: Publish to RubyGems
+
 on:
   push:
     tags:
@@ -22,8 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
-          ruby-version: ruby
+          ruby-version: 3.2
 
       # Release
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -1,0 +1,29 @@
+---
+name: Publish to RubyGems
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  id-token: write
+  contents: write
+
+# see: https://guides.rubygems.org/trusted-publishing/adding-a-publisher/
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         ruby-version:
           - "3.2"
-          - "3.3"
-          - "3.4"
+#          - "3.3"
+#          - "3.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+        ruby-version:
+          - "3.2"
+          - "3.3"
+          - "3.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         ruby-version:
           - "3.2"
@@ -16,7 +16,7 @@ jobs:
           - "3.4"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         ruby-version:
           - "3.2"
-#          - "3.3"
-#          - "3.4"
+          - "3.3"
+          - "3.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     prism (1.4.0)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (10.5.0)
+    rake (13.3.0)
     regexp_parser (2.11.0)
     rexml (3.4.1)
     rspec (3.13.1)
@@ -83,7 +83,7 @@ DEPENDENCIES
   httpclient
   presto-client (~> 0.5.6)
   presto-metrics!
-  rake (~> 10.0)
+  rake (~> 13.0)
   rspec
   standard (~> 1.16.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+PATH
+  remote: .
+  specs:
+    presto-metrics (0.5.0)
+      httparty
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    bigdecimal (3.2.2)
+    csv (3.3.5)
+    diff-lcs (1.6.2)
+    faraday (0.17.6)
+      multipart-post (>= 1.2, < 3)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    httpclient (2.9.0)
+      mutex_m
+    json (2.13.2)
+    mini_mime (1.1.5)
+    msgpack (1.8.0)
+    multi_xml (0.7.2)
+      bigdecimal (~> 3.1)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    presto-client (0.5.14)
+      faraday (~> 0.12)
+      msgpack (>= 0.7.0)
+    prism (1.4.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (10.5.0)
+    regexp_parser (2.11.0)
+    rexml (3.4.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rubocop (1.35.1)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-performance (1.14.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.13.0)
+    standard (1.16.1)
+      rubocop (= 1.35.1)
+      rubocop-performance (= 1.14.3)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  x86_64-darwin-21
+  x86_64-darwin-23
+
+DEPENDENCIES
+  bundler (~> 2.0)
+  httpclient
+  presto-client (~> 0.5.6)
+  presto-metrics!
+  rake (~> 10.0)
+  rspec
+  standard (~> 1.16.0)
+
+BUNDLED WITH
+   2.6.2

--- a/presto-metrics.gemspec
+++ b/presto-metrics.gemspec
@@ -18,12 +18,18 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 3.2.0"
+
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "presto-client", '~> 0.5.6'
   spec.add_development_dependency "httpclient"
   spec.add_development_dependency "standard", ["~> 1.16.0"]
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+    spec.add_dependency("base64")
+  end
 
   spec.add_runtime_dependency "httparty"
 

--- a/presto-metrics.gemspec
+++ b/presto-metrics.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "presto-client", '~> 0.5.6'
   spec.add_development_dependency "httpclient"


### PR DESCRIPTION
## Overview

- Change test target ruby versions
  - https://endoflife.date/ruby
- Bump dependency libraries
- Add `publisher.yml` to publish gems from Gtihub Actions
  - https://github.com/rubygems/release-gem
  - https://guides.rubygems.org/trusted-publishing/adding-a-publisher/