### PR TITLE
fix: remove bundler dev dependency to support bundler 4.x

### DIFF
--- a/presto-metrics.gemspec
+++ b/presto-metrics.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.2.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "presto-client", '~> 0.5.6'


### PR DESCRIPTION
## Summary

- Removes `spec.add_development_dependency "bundler", "~> 2.0"` from `presto-metrics.gemspec`
- The `~> 2.0` constraint conflicts with bundler 4.x, which is now installed by default in CI since `Gemfile.lock` (which previously pinned `BUNDLED WITH 2.6.2`) was removed from version control
- Declaring bundler as a gemspec dev dependency is non-standard — bundler is the tool that manages deps, not a dep itself; the CI workflow handles bundler installation directly via `gem install bundler`

## Root cause

Commit `5a1fa48` (remove Gemfile.lock) triggered [this CI failure](https://github.com/xerial/presto-metrics/actions/runs/27600075783/job/81598728296): `gem install bundler` installs 4.0.14, which doesn't satisfy `~> 2.0`, causing `bundle install` to exit with code 6.

## Test plan

- [x] CI passes across Ruby 3.2, 3.3, 3.4 on this PR